### PR TITLE
User movies refactor

### DIFF
--- a/MovieProject/src/main/java/com/MattyDubs/MovieProject/controller/ForumController.java
+++ b/MovieProject/src/main/java/com/MattyDubs/MovieProject/controller/ForumController.java
@@ -26,7 +26,6 @@ import java.util.List;
 @RequestMapping("/forum")
 public class ForumController {
 
-    //TODO Add validation on inputs. Probably should setup a requestMatcher for forums LOL.
 
     private final PostService postService;
     private final ReplyService replyService;
@@ -70,7 +69,6 @@ public class ForumController {
      */
     @GetMapping("/viewPost")
     public String showPost(@RequestParam("id") int id, Model model) {
-        // n+1 Post post = postService.findById(id);
         Post post = postService.findPostUserAndReplies(id);
         model.addAttribute("post", post);
         return "/forumPages/PostView :: postView";

--- a/MovieProject/src/main/java/com/MattyDubs/MovieProject/dao/MovieDAO.java
+++ b/MovieProject/src/main/java/com/MattyDubs/MovieProject/dao/MovieDAO.java
@@ -1,7 +1,6 @@
 package com.MattyDubs.MovieProject.dao;
 
 
-import com.MattyDubs.MovieProject.entity.CustomUser;
 import com.MattyDubs.MovieProject.entity.Movie;
 
 import java.util.List;
@@ -13,7 +12,7 @@ import java.util.List;
  */
 public interface MovieDAO {
 
-    void save(Movie movie, CustomUser user);
+    Movie save(Movie movie);
 
     void deleteMovie(Movie movie);
 
@@ -23,14 +22,9 @@ public interface MovieDAO {
 
     List<Movie> findAll();
 
-    List<Movie> findAllByUser(CustomUser user);
-
-    List<Movie> findByTitleYearUser(String title, String year, CustomUser user);
-
     Movie singleFindByTitleYear(String title, String year);
 
     void updateMovie(Movie movie);
 
-    boolean movieUserCheck(CustomUser user, String title);
 
 }

--- a/MovieProject/src/main/java/com/MattyDubs/MovieProject/dao/MovieDAOImpl.java
+++ b/MovieProject/src/main/java/com/MattyDubs/MovieProject/dao/MovieDAOImpl.java
@@ -1,6 +1,5 @@
 package com.MattyDubs.MovieProject.dao;
 
-import com.MattyDubs.MovieProject.entity.CustomUser;
 import com.MattyDubs.MovieProject.entity.Movie;
 import jakarta.persistence.EntityManager;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,15 +14,13 @@ public class MovieDAOImpl implements MovieDAO {
     private final EntityManager entityManager;
 
     @Autowired
-    public MovieDAOImpl(EntityManager entityManager, UserDAO userDAO) {
+    public MovieDAOImpl(EntityManager entityManager) {
         this.entityManager = entityManager;
     }
 
     @Override
-    public void save(Movie movie, CustomUser user) {
-        List<Movie> movies = findByTitleYearUser(movie.getTitle(), movie.getYear(), user);
-        if (movies.isEmpty())
-            entityManager.persist(movie);
+    public Movie save(Movie movie) {
+        return entityManager.merge(movie);
     }
 
     @Override
@@ -54,19 +51,6 @@ public class MovieDAOImpl implements MovieDAO {
         return entityManager.createQuery("SELECT m FROM Movie m", Movie.class).getResultList();
     }
 
-    public List<Movie> findAllByUser(CustomUser user) {
-        return entityManager.createQuery("SELECT m FROM Movie m WHERE m.user.id=:id", Movie.class)
-                .setParameter("id", user.getId())
-                .getResultList();
-    }
-
-    public List<Movie> findByTitleYearUser(String title, String year, CustomUser user) {
-        return entityManager.createQuery("SELECT m FROM Movie m WHERE m.title = :title AND m.year=:year AND m.user.id = :id", Movie.class)
-                .setParameter("title", title)
-                .setParameter("year", year)
-                .setParameter("id", user.getId())
-                .getResultList();
-    }
 
     public Movie singleFindByTitleYear(String title, String year) {
         return entityManager.createQuery("SELECT m FROM Movie m WHERE m.title = :title AND m.year=:year", Movie.class)
@@ -75,13 +59,11 @@ public class MovieDAOImpl implements MovieDAO {
                 .getResultList().stream().findFirst().orElse(null);
     }
 
-    @Override
-    public boolean movieUserCheck(CustomUser user, String title) {
-        long exists = entityManager.createQuery("SELECT COUNT(m) FROM Movie m WHERE m.title=:title AND m.user.id=:id", Long.class)
+
+    public long beforeSaveCheck(String title) {
+        return entityManager.createQuery("SELECT COUNT(m) FROM Movie m WHERE m.title=:title", Long.class)
                 .setParameter("title", title)
-                .setParameter("id", user.getId())
                 .getSingleResult();
-        return exists == 0;
     }
 
 }

--- a/MovieProject/src/main/java/com/MattyDubs/MovieProject/dao/UserDAOImpl.java
+++ b/MovieProject/src/main/java/com/MattyDubs/MovieProject/dao/UserDAOImpl.java
@@ -1,7 +1,7 @@
 package com.MattyDubs.MovieProject.dao;
 
 import com.MattyDubs.MovieProject.entity.CustomUser;
-import com.MattyDubs.MovieProject.entity.Movie;
+import com.MattyDubs.MovieProject.entity.UserMovies;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.NoResultException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -64,7 +64,7 @@ public class UserDAOImpl implements UserDAO {
 
     @Override
     public CustomUser getUserAndMovies(CustomUser user) {
-        List<Movie> movies = entityManager.createQuery("SELECT m FROM Movie m WHERE m.user.id = :id", Movie.class)
+        List<UserMovies> movies = entityManager.createQuery("SELECT m FROM UserMovies m LEFT JOIN FETCH m.movie WHERE m.user.id = :id", UserMovies.class)
                 .setParameter("id", user.getId())
                 .getResultList();
         user.setMovies(movies);

--- a/MovieProject/src/main/java/com/MattyDubs/MovieProject/dao/UserMoviesDAO.java
+++ b/MovieProject/src/main/java/com/MattyDubs/MovieProject/dao/UserMoviesDAO.java
@@ -1,0 +1,61 @@
+package com.MattyDubs.MovieProject.dao;
+
+import com.MattyDubs.MovieProject.entity.CustomUser;
+import com.MattyDubs.MovieProject.entity.UserMovies;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.NoResultException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class UserMoviesDAO {
+
+    private final EntityManager entityManager;
+
+    @Autowired
+    public UserMoviesDAO(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    public UserMovies findById(int id) {
+        return entityManager.find(UserMovies.class, id);
+    }
+
+    public void saveMovieForUser(UserMovies userMovies) {
+        entityManager.persist(userMovies);
+    }
+
+    public void deleteMovieForUser(UserMovies userMovies) {
+        entityManager.remove(userMovies);
+    }
+
+    public void updateUserMovie(UserMovies userMovies) {
+        entityManager.merge(userMovies);
+    }
+
+    public List<UserMovies> findUserMovies(CustomUser user) {
+        return entityManager.createQuery("SELECT um FROM UserMovies um LEFT JOIN FETCH um.movie WHERE um.user.id=:id", UserMovies.class)
+                .setParameter("id", user.getId())
+                .getResultList();
+    }
+
+    public long checkForDuplicateSave(CustomUser user, String title) {
+        return entityManager.createQuery("SELECT COUNT(um) FROM UserMovies um WHERE um.user.id=:id AND um.movie.title=:title", Long.class)
+                .setParameter("id", user.getId())
+                .setParameter("title", title)
+                .getSingleResult();
+    }
+
+    public UserMovies findByUserAndTitle(CustomUser user, String title) {
+        try {
+            return entityManager.createQuery("SELECT um FROM UserMovies um WHERE um.movie.title=:title AND um.user.id=:id", UserMovies.class)
+                    .setParameter("title", title)
+                    .setParameter("id", user.getId())
+                    .getSingleResult();
+        } catch (NoResultException e) {
+            throw new RuntimeException("No UM found with title " + title + " and id " + user.getId());
+        }
+    }
+}

--- a/MovieProject/src/main/java/com/MattyDubs/MovieProject/entity/CustomUser.java
+++ b/MovieProject/src/main/java/com/MattyDubs/MovieProject/entity/CustomUser.java
@@ -42,7 +42,7 @@ public class CustomUser {
     private boolean enabled;
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
-    private List<Movie> movies;
+    private List<UserMovies> movies;
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
     private List<Post> posts;
@@ -81,11 +81,11 @@ public class CustomUser {
         this.enabled = enabled;
     }
 
-    public List<Movie> getMovies() {
+    public List<UserMovies> getMovies() {
         return movies;
     }
 
-    public void setMovies(List<Movie> movies) {
+    public void setMovies(List<UserMovies> movies) {
         this.movies = movies;
     }
 

--- a/MovieProject/src/main/java/com/MattyDubs/MovieProject/entity/Movie.java
+++ b/MovieProject/src/main/java/com/MattyDubs/MovieProject/entity/Movie.java
@@ -60,12 +60,12 @@ public class Movie {
     @Column(name = "director")
     private String director;
 
-    @Column(name = "watched", columnDefinition = "boolean default false")
-    private boolean watched;
+//    @Column(name = "watched", columnDefinition = "boolean default false")
+//    private boolean watched;
 
-    @ManyToOne
-    @JoinColumn(name = "user_id")
-    private CustomUser user;
+//    @ManyToOne
+//    @JoinColumn(name = "user_id")
+//    private CustomUser user;
 
     @JsonProperty("Type")
     @Transient
@@ -90,13 +90,13 @@ public class Movie {
         this.director = director;
     }
 
-    public boolean getWatched() {
-        return this.watched;
-    }
-
-    public void setWatched(Boolean bool) {
-        this.watched = bool;
-    }
+//    public boolean getWatched() {
+//        return this.watched;
+//    }
+//
+//    public void setWatched(Boolean bool) {
+//        this.watched = bool;
+//    }
 
     public String getType() {
         return type;
@@ -106,13 +106,13 @@ public class Movie {
         this.type = type;
     }
 
-    public CustomUser getUser() {
-        return user;
-    }
-
-    public void setUser(CustomUser user) {
-        this.user = user;
-    }
+//    public CustomUser getUser() {
+//        return user;
+//    }
+//
+//    public void setUser(CustomUser user) {
+//        this.user = user;
+//    }
 
     public String getImdbURL() {
         String imdbURL = "https://www.imdb.com/title/";
@@ -225,12 +225,12 @@ public class Movie {
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) return false;
         Movie movie = (Movie) o;
-        return id == movie.id && Objects.equals(title, movie.title) && Objects.equals(year, movie.year) && Objects.equals(rated, movie.rated) && Objects.equals(genre, movie.genre) && Objects.equals(actors, movie.actors) && Objects.equals(plot, movie.plot) && Objects.equals(score, movie.score) && Objects.equals(imageURL, movie.imageURL) && Objects.equals(imdbId, movie.imdbId) && Objects.equals(director, movie.director) && Objects.equals(user, movie.user);
+        return id == movie.id && Objects.equals(title, movie.title) && Objects.equals(year, movie.year) && Objects.equals(rated, movie.rated) && Objects.equals(genre, movie.genre) && Objects.equals(actors, movie.actors) && Objects.equals(plot, movie.plot) && Objects.equals(score, movie.score) && Objects.equals(imageURL, movie.imageURL) && Objects.equals(imdbId, movie.imdbId) && Objects.equals(director, movie.director);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, title, year, rated, genre, actors, plot, score, imageURL, imdbId, director, user);
+        return Objects.hash(id, title, year, rated, genre, actors, plot, score, imageURL, imdbId, director);
     }
 
 }

--- a/MovieProject/src/main/java/com/MattyDubs/MovieProject/entity/UserMovies.java
+++ b/MovieProject/src/main/java/com/MattyDubs/MovieProject/entity/UserMovies.java
@@ -1,0 +1,78 @@
+package com.MattyDubs.MovieProject.entity;
+
+import jakarta.persistence.*;
+
+
+@Entity
+@Table(name = "usermovies")
+public class UserMovies {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private CustomUser user;
+
+    @ManyToOne
+    @JoinColumn(name = "movie_id")
+    private Movie movie;
+
+    @Column(name = "watched", columnDefinition = "boolean default false")
+    private boolean watched;
+
+    @Column(name = "userrating")
+    private int userRating;
+
+    public UserMovies() {
+
+    }
+
+    public UserMovies(CustomUser user, Movie movie) {
+        this.user = user;
+        this.movie = movie;
+        this.watched = false;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public CustomUser getUser() {
+        return user;
+    }
+
+    public void setUser(CustomUser user) {
+        this.user = user;
+    }
+
+    public Movie getMovie() {
+        return movie;
+    }
+
+    public void setMovie(Movie movie) {
+        this.movie = movie;
+    }
+
+    public boolean getWatched() {
+        return watched;
+    }
+
+    public void setWatched(boolean watched) {
+        this.watched = watched;
+    }
+
+    public int getUserRating() {
+        return userRating;
+    }
+
+    public void setUserRating(int userRating) {
+        this.userRating = userRating;
+    }
+
+}

--- a/MovieProject/src/main/java/com/MattyDubs/MovieProject/event/EmailSender.java
+++ b/MovieProject/src/main/java/com/MattyDubs/MovieProject/event/EmailSender.java
@@ -9,10 +9,9 @@ import org.springframework.stereotype.Service;
 @Service
 public class EmailSender {
 
+    private final JavaMailSender mailSender;
     @Value("${spring.mail.username}")
     private String senderEmail;
-
-    private final JavaMailSender mailSender;
 
     @Autowired
     public EmailSender(JavaMailSender mailSender) {

--- a/MovieProject/src/main/java/com/MattyDubs/MovieProject/event/Listener.java
+++ b/MovieProject/src/main/java/com/MattyDubs/MovieProject/event/Listener.java
@@ -1,7 +1,7 @@
 package com.MattyDubs.MovieProject.event;
 
 import com.MattyDubs.MovieProject.entity.CustomUser;
-import com.MattyDubs.MovieProject.entity.Movie;
+import com.MattyDubs.MovieProject.entity.UserMovies;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.event.EventListener;
 import org.springframework.mail.MailSendException;
@@ -32,10 +32,10 @@ public class Listener {
     @EventListener
     public void sendMovieList(MovieEmailRequestEvent event) {
         CustomUser user = event.getUser();
-        List<Movie> movies = event.getMovies();
+        List<UserMovies> movies = event.getMovies();
         String str = "";
-        for (Movie movie : movies) {
-            str += movie.getTitle() + "\n";
+        for (UserMovies movie : movies) {
+            str += movie.getMovie().getTitle() + "\n";
         }
         try {
             emailSender.sendEmail(user.getEmail(), "Movie-List Request", str);

--- a/MovieProject/src/main/java/com/MattyDubs/MovieProject/event/MovieEmailRequestEvent.java
+++ b/MovieProject/src/main/java/com/MattyDubs/MovieProject/event/MovieEmailRequestEvent.java
@@ -1,16 +1,16 @@
 package com.MattyDubs.MovieProject.event;
 
 import com.MattyDubs.MovieProject.entity.CustomUser;
-import com.MattyDubs.MovieProject.entity.Movie;
+import com.MattyDubs.MovieProject.entity.UserMovies;
 
 import java.util.List;
 
 public class MovieEmailRequestEvent {
 
-    private final List<Movie> movies;
+    private final List<UserMovies> movies;
     private final CustomUser user;
 
-    public MovieEmailRequestEvent(List<Movie> movies, CustomUser user) {
+    public MovieEmailRequestEvent(List<UserMovies> movies, CustomUser user) {
         this.movies = movies;
         this.user = user;
     }
@@ -19,7 +19,7 @@ public class MovieEmailRequestEvent {
         return user;
     }
 
-    public List<Movie> getMovies() {
+    public List<UserMovies> getMovies() {
         return movies;
     }
 

--- a/MovieProject/src/main/java/com/MattyDubs/MovieProject/service/MovieCheckService.java
+++ b/MovieProject/src/main/java/com/MattyDubs/MovieProject/service/MovieCheckService.java
@@ -35,15 +35,18 @@ public class MovieCheckService {
                 .orElse(null);
         if (tm != null) {
             System.out.println("Found with top-movie DB!");
-            return movieUtil.mapFromTopMovieModel(tm);
+            Movie movie = movieUtil.mapFromTopMovieModel(tm);
+            return movieService.save(movie);
         } else {
             Movie movie = movieService.singleFindByTitleYear(title, year);
             if (movie != null) {
                 System.out.println("Found with movie-db!");
-                return movieUtil.copyMovie(movie);
+                return movie;
             } else {
+                //TODO: SAVE THE MOVIE AFTER THE API CALL, MOVIE TABLE IS NOW READONLY.
                 System.out.println("Found with API!");
-                return movieAPIService.getSingleMovie(title, year);
+                Movie apiMovie = movieAPIService.getSingleMovie(title, year);
+                return movieService.save(apiMovie);
             }
         }
 

--- a/MovieProject/src/main/java/com/MattyDubs/MovieProject/service/MovieService.java
+++ b/MovieProject/src/main/java/com/MattyDubs/MovieProject/service/MovieService.java
@@ -1,6 +1,5 @@
 package com.MattyDubs.MovieProject.service;
 
-import com.MattyDubs.MovieProject.entity.CustomUser;
 import com.MattyDubs.MovieProject.entity.Movie;
 
 import java.util.List;
@@ -10,7 +9,7 @@ import java.util.List;
  * the movie entity. This class is part of the service layer to be used by the controller.
  */
 public interface MovieService {
-    void save(Movie movie, CustomUser user);
+    Movie save(Movie movie);
 
     void deleteMovie(int id);
 
@@ -20,23 +19,9 @@ public interface MovieService {
 
     List<Movie> findAll();
 
-    List<Movie> findAllByUser(CustomUser user);
-
-    List<Movie> findByTitleYearUser(String title, String year, CustomUser user);
 
     Movie singleFindByTitleYear(String title, String year);
 
-    /**
-     * saveMovieForUser method used to save a movie to the proper user. The method will check whether the user
-     * has already saved the movie. If not, then it will call the movieDAO to save the movie to the DB.
-     *
-     * @param user  The current logged-in user.
-     * @param movie The movie to be saved.
-     * @return The users movie personal movie list.
-     */
-    void saveMovieForUser(CustomUser user, Movie movie);
-
     void updateMovie(Movie movie);
 
-    boolean movieUserCheck(CustomUser user, String title);
 }

--- a/MovieProject/src/main/java/com/MattyDubs/MovieProject/service/MovieServiceImpl.java
+++ b/MovieProject/src/main/java/com/MattyDubs/MovieProject/service/MovieServiceImpl.java
@@ -1,7 +1,6 @@
 package com.MattyDubs.MovieProject.service;
 
 import com.MattyDubs.MovieProject.dao.MovieDAO;
-import com.MattyDubs.MovieProject.entity.CustomUser;
 import com.MattyDubs.MovieProject.entity.Movie;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -22,8 +21,8 @@ public class MovieServiceImpl implements MovieService {
 
     @Override
     @Transactional
-    public void save(Movie movie, CustomUser user) {
-        movieDAO.save(movie, user);
+    public Movie save(Movie movie) {
+        return movieDAO.save(movie);
     }
 
     @Override
@@ -49,31 +48,12 @@ public class MovieServiceImpl implements MovieService {
         return movieDAO.findAll();
     }
 
-    @Override
-    public List<Movie> findAllByUser(CustomUser user) {
-        return movieDAO.findAllByUser(user);
-    }
-
-    @Override
-    public List<Movie> findByTitleYearUser(String title, String year, CustomUser user) {
-        return movieDAO.findByTitleYearUser(title, year, user);
-    }
 
     @Override
     public Movie singleFindByTitleYear(String title, String year) {
         return movieDAO.singleFindByTitleYear(title, year);
     }
 
-    @Override
-    @Transactional
-    public void saveMovieForUser(CustomUser user, Movie movie) {
-        if (movieUserCheck(user, movie.getTitle())) {
-            movie.setUser(user);
-            //TODO below would break with UserDetails impl.
-            user.getMovies().add(movie);
-            movieDAO.save(movie, user);
-        }
-    }
 
     @Override
     @Transactional
@@ -81,8 +61,4 @@ public class MovieServiceImpl implements MovieService {
         movieDAO.updateMovie(movie);
     }
 
-    @Override
-    public boolean movieUserCheck(CustomUser user, String title) {
-        return movieDAO.movieUserCheck(user, title);
-    }
 }

--- a/MovieProject/src/main/java/com/MattyDubs/MovieProject/service/UserMoviesService.java
+++ b/MovieProject/src/main/java/com/MattyDubs/MovieProject/service/UserMoviesService.java
@@ -1,0 +1,70 @@
+package com.MattyDubs.MovieProject.service;
+
+import com.MattyDubs.MovieProject.dao.UserMoviesDAO;
+import com.MattyDubs.MovieProject.entity.CustomUser;
+import com.MattyDubs.MovieProject.entity.Movie;
+import com.MattyDubs.MovieProject.entity.UserMovies;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class UserMoviesService {
+
+    private final UserMoviesDAO userMoviesDAO;
+
+    @Autowired
+    public UserMoviesService(UserMoviesDAO userMoviesDAO) {
+        this.userMoviesDAO = userMoviesDAO;
+    }
+
+    public UserMovies findById(int id) {
+        return userMoviesDAO.findById(id);
+    }
+
+    @Transactional
+    public void saveMovieForUser(Movie movie, CustomUser user) {
+        if (checkForDuplicateSave(user, movie.getTitle())) {
+            UserMovies userMovies = new UserMovies();
+            userMovies.setUser(user);
+            userMovies.setMovie(movie);
+            userMoviesDAO.saveMovieForUser(userMovies);
+        }
+    }
+
+    @Transactional
+    public void deleteMovieForUser(UserMovies userMovies) {
+        userMovies.setUser(null);
+        userMovies.setMovie(null);
+        userMoviesDAO.deleteMovieForUser(userMovies);
+    }
+
+    @Transactional
+    public void updateWatchedStatus(UserMovies userMovies, String status) {
+        boolean watchedStatus = Boolean.parseBoolean(status);
+        userMovies.setWatched(watchedStatus);
+        userMoviesDAO.updateUserMovie(userMovies);
+    }
+
+    public List<UserMovies> findUserMovies(CustomUser user) {
+        return userMoviesDAO.findUserMovies(user);
+    }
+
+    public boolean checkForDuplicateSave(CustomUser user, String title) {
+        long exists = userMoviesDAO.checkForDuplicateSave(user, title);
+        return exists == 0;
+    }
+
+    public UserMovies findByUserAndTitle(CustomUser user, String title) {
+        return userMoviesDAO.findByUserAndTitle(user, title);
+    }
+
+    @Transactional
+    public void updateScore(int id, String score){
+        UserMovies movieToUpdate = findById(id);
+        movieToUpdate.setUserRating(Integer.parseInt(score));
+        userMoviesDAO.updateUserMovie(movieToUpdate);
+    }
+}

--- a/MovieProject/src/main/java/com/MattyDubs/MovieProject/service/UserService.java
+++ b/MovieProject/src/main/java/com/MattyDubs/MovieProject/service/UserService.java
@@ -1,7 +1,7 @@
 package com.MattyDubs.MovieProject.service;
 
 import com.MattyDubs.MovieProject.entity.CustomUser;
-import com.MattyDubs.MovieProject.entity.Movie;
+import com.MattyDubs.MovieProject.entity.UserMovies;
 
 import java.util.List;
 
@@ -15,22 +15,9 @@ public interface UserService {
 
     CustomUser findByUsername(String username);
 
-    CustomUser findUserAndMovies(String username);
-
-    /**
-     * updateMovieForUser method is used to update the watched status of a movie for a given user. Works with the
-     * update methods in the MovieController class.
-     *
-     * @param user   user for the current logged-in user.
-     * @param title  Title of the movie to update.
-     * @param year   Year that the movie was released.
-     * @param status Watched or unwatched status of the movie, string holds value of either true or false.
-     */
-    void updateMovieForUser(CustomUser user, String title, String year, String status);
-
     boolean checkUserExists(String username);
 
-    List<Movie> getPagedMovies(CustomUser user, int page, int size);
+    List<UserMovies> getPagedMovies(CustomUser user, int page, int size);
 
     CustomUser getUserAndMovies(CustomUser user);
 

--- a/MovieProject/src/main/java/com/MattyDubs/MovieProject/service/UserServiceImpl.java
+++ b/MovieProject/src/main/java/com/MattyDubs/MovieProject/service/UserServiceImpl.java
@@ -2,7 +2,7 @@ package com.MattyDubs.MovieProject.service;
 
 import com.MattyDubs.MovieProject.dao.UserDAO;
 import com.MattyDubs.MovieProject.entity.CustomUser;
-import com.MattyDubs.MovieProject.entity.Movie;
+import com.MattyDubs.MovieProject.entity.UserMovies;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,12 +14,10 @@ import java.util.List;
 public class UserServiceImpl implements UserService {
 
     private final UserDAO userDAO;
-    private final MovieService movieService;
 
     @Autowired
-    public UserServiceImpl(UserDAO userDAO, MovieService movieService) {
+    public UserServiceImpl(UserDAO userDAO) {
         this.userDAO = userDAO;
-        this.movieService = movieService;
     }
 
     @Override
@@ -33,42 +31,14 @@ public class UserServiceImpl implements UserService {
         return userDAO.findByUsername(username);
     }
 
-    @Override
-    public CustomUser findUserAndMovies(String username) {
-        return userDAO.findUserAndMovies(username);
-    }
-
-    @Override
-    @Transactional
-    public void updateMovieForUser(CustomUser user, String title, String year, String status) {
-        //TODO Make use of OPTIONAL here? Maybe ifPresent
-        //TODO Again, we'll have to fetch with... user.setMovies(movieService.findAllByUser(user));
-        //user.setMovies(movieService.findAllByUser(user));
-        Movie movieToUpdate = user.getMovies()
-                //user.getMovies()
-                .stream()
-                .filter(mov -> mov.getTitle().equals(title) && mov.getYear().equals(year))
-                .findFirst()
-//              .ifPresent(movie->{
-//                    movie.setWatched(Boolean.valueOf(status));
-//                    movieService.updateMovie(movie);
-//                });
-                .orElse(null);
-        if (movieToUpdate != null) {
-            movieToUpdate.setWatched(Boolean.valueOf(status));
-            movieService.updateMovie(movieToUpdate);
-        }
-    }
 
     @Override
     public boolean checkUserExists(String username) {
         return userDAO.checkUserExists(username);
     }
 
-    public List<Movie> getPagedMovies(CustomUser user, int page, int size) {
-        //TODO This is what we'll have to do. Can't lazy load with userdetails fetch... user.setMovies(movieService.findAllByUser(user));
-        //user.setMovies(movieService.findAllByUser(user));
-        List<Movie> movies = user.getMovies();
+    public List<UserMovies> getPagedMovies(CustomUser user, int page, int size) {
+        List<UserMovies> movies = user.getMovies();
         int start = (page - 1) * size;
         int end = Math.min(start + size, movies.size());
         return movies.subList(start, end);

--- a/MovieProject/src/main/java/com/MattyDubs/MovieProject/util/MovieUtil.java
+++ b/MovieProject/src/main/java/com/MattyDubs/MovieProject/util/MovieUtil.java
@@ -23,21 +23,21 @@ public class MovieUtil {
      * @param movie The movie object to be copied.
      * @return A new movie object with the same fields as the original movie.
      */
-    public Movie copyMovie(Movie movie) {
-        Movie newMovie = new Movie();
-        newMovie.setUser(movie.getUser());
-        newMovie.setYear(movie.getYear());
-        newMovie.setTitle(movie.getTitle());
-        newMovie.setActors(movie.getActors());
-        newMovie.setImdbId(movie.getImdbId());
-        newMovie.setDirector(movie.getDirector());
-        newMovie.setRated(movie.getRated());
-        newMovie.setScore(movie.getScore());
-        newMovie.setGenre(movie.getGenre());
-        newMovie.setPlot(movie.getPlot());
-        newMovie.setImageURL(movie.getImageURL());
-        return newMovie;
-    }
+//    public Movie copyMovie(Movie movie) {
+//        Movie newMovie = new Movie();
+//        newMovie.setId(movie.getId());
+//        newMovie.setYear(movie.getYear());
+//        newMovie.setTitle(movie.getTitle());
+//        newMovie.setActors(movie.getActors());
+//        newMovie.setImdbId(movie.getImdbId());
+//        newMovie.setDirector(movie.getDirector());
+//        newMovie.setRated(movie.getRated());
+//        newMovie.setScore(movie.getScore());
+//        newMovie.setGenre(movie.getGenre());
+//        newMovie.setPlot(movie.getPlot());
+//        newMovie.setImageURL(movie.getImageURL());
+//        return newMovie;
+//    }
 
     /**
      * mapFromTopMovieModel method is used to map the fields of a top-movie to a new movie object. This is used for if

--- a/MovieProject/src/main/resources/application.properties
+++ b/MovieProject/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.application.name=MovieProject
 
-movieKey= ${API_KEY}
-movieURL= ${API_URL} 
+movieKey=${API_KEY}
+movieURL=https://www.omdbapi.com/?apikey=
 
 spring.datasource.url=${DB_URL}
 spring.datasource.username=${DB_USERNAME}

--- a/MovieProject/src/main/resources/templates/fragments/personal-list.html
+++ b/MovieProject/src/main/resources/templates/fragments/personal-list.html
@@ -12,34 +12,46 @@
             <th>Rating</th>
             <th>Actions</th>
             <th>Watched</th>
+            <th>My Score</th>
         </tr>
         </thead>
         <tbody>
         <tr th:each="movie : ${movies}">
-            <td><img th:src="${movie.imageURL}" alt="Movie Poster" class="movie-poster"></td>
-            <td th:text="${movie.title}" style="word-wrap: break-word; white-space: normal;"></td>
-            <td th:text="${movie.year}" style="word-wrap: break-word;"></td>
-            <td th:text="${movie.genre}" style="word-wrap: break-word;"></td>
-            <td th:text="${movie.rated}" style="word-wrap: break-word;"></td>
+            <td><img th:src="${movie.movie.imageURL}" alt="Movie Poster" class="movie-poster"></td>
+            <td th:text="${movie.movie.title}" style="word-wrap: break-word; white-space: normal;"></td>
+            <td th:text="${movie.movie.year}" style="word-wrap: break-word;"></td>
+            <td th:text="${movie.movie.genre}" style="word-wrap: break-word;"></td>
+            <td th:text="${movie.movie.rated}" style="word-wrap: break-word;"></td>
             <td>
-                <a class="btn btn-dark btn-sm btn-custom"
-                   hx-swap="innerHTML"
-                   hx-target="#show-movie"
-                   th:hx-get="@{/movies/showMovieDetails(page=${page}, title=${movie.title}, year=${movie.year})}"
-                   onclick="scrollToMovieDetails()">Details</a>
-                <a class="btn btn-danger btn-sm btn-custom"
-                    th:hx-get="@{/movies/deleteMovie(page = ${page}, id=${movie.id})}"
-                    hx-target="#movieResults"
-                    hx-swap="innerHTML">Remove</a>
-                <div th:id="'watchButton'+${movie.id}">
-                <a class="btn btn-sm btn-secondary"
-                   hx:get="@{/movies/updateForm(page = ${page}, title = ${movie.title}, year =${movie.year})}"
-                   th:hx-target=" '#watchButton'+ ${movie.id}"
-                   hx-swap="innerHTML">Update</a>
+                <div class="d-flex flex-column gap-2">
+                    <a class="btn btn-dark btn-sm w-100 text-center"
+                       hx-swap="innerHTML"
+                       hx-target="#show-movie"
+                       th:hx-get="@{/movies/showMovieDetails(page=${page}, title=${movie.movie.title}, year=${movie.movie.year})}"
+                       onclick="scrollToMovieDetails()">Details</a>
+                    <a class="btn btn-danger btn-sm w-100 text-center"
+                       th:hx-get="@{/movies/deleteMovie(page = ${page}, id=${movie.id})}"
+                       hx-target="#movieResults"
+                       hx-swap="innerHTML">Remove</a>
+                    <div th:id="'watchButton'+${movie.id}">
+                        <a class="btn btn-secondary btn-sm w-100 text-center"
+                           hx:get="@{/movies/updateForm(page = ${page}, title = ${movie.movie.title}, year =${movie.movie.year})}"
+                           th:hx-target=" '#watchButton'+ ${movie.id}"
+                           hx-swap="innerHTML">Update Watched</a>
+                    </div>
+                    <div th:if="${movie.watched}" th:id="'scoreButton'+${movie.id}">
+                        <a class="btn btn-info btn-sm w-100 text-center"
+                           hx:get="@{/movies/updateScoreForm(page = ${page}, id=${movie.id})}"
+                           th:hx-target=" '#scoreButton'+ ${movie.id}"
+                           hx-swap="innerHTML">Update Score</a>
+                    </div>
                 </div>
             </td>
-            <td th:if="${movie.watched} == false">&#x274c</td>
-            <td th:if="${movie.watched} == true">&#10004;</td>
+            <td th:if="${movie.watched} == false" class="text-success text-center align-middle">&#x274c</td>
+            <td th:if="${movie.watched} == true" class="text-success text-center align-middle">&#10004;</td>
+            <td th:if="${movie.watched == true && movie.userRating > 0}" th:text="${movie.userRating} + '/10'"></td>
+            <td th:if="${movie.watched == false && movie.userRating == 0}">Not yet Rated</td>
+            <td th:if="${movie.watched == true && movie.userRating == 0}">Not yet Rated</td>
         </tr>
         </tbody>
     </table>

--- a/MovieProject/src/main/resources/templates/fragments/updateScoreForm.html
+++ b/MovieProject/src/main/resources/templates/fragments/updateScoreForm.html
@@ -1,0 +1,19 @@
+<div th:fragment="updateScoreForm">
+    <form method="POST" th:action="@{/movies/updateScore}">
+        <select name="score">
+            <option value="1">1</option>
+            <option value="2">2</option>
+            <option value="3">3</option>
+            <option value="4">4</option>
+            <option value="5">5</option>
+            <option value="6">6</option>
+            <option value="7">7</option>
+            <option value="8">8</option>
+            <option value="9">9</option>
+            <option value="10">10</option>
+        </select>
+        <input type="hidden" name="id" th:value="${id}">
+        <input type="hidden" name="page" th:value="${page}">
+        <button type="submit" hx:post="@{/movies/updateScore}" hx-swap="innerHTML" hx-target="#movieResults">Update Score</button>
+    </form>
+</div>

--- a/MovieProject/src/test/java/com/MattyDubs/MovieProject/MovieProjectApplicationTests.java
+++ b/MovieProject/src/test/java/com/MattyDubs/MovieProject/MovieProjectApplicationTests.java
@@ -21,16 +21,16 @@ class MovieProjectApplicationTests {
 	void contextLoads() {
 	}
 
-	@Test
-	public void testCopy(){
-		Movie movie = new Movie();
-		movie.setYear("1999");
-		movie.setTitle("Matrix");
-
-		Movie copiedMovie = movieUtil.copyMovie(movie);
-		assertEquals("Matrix", copiedMovie.getTitle());
-		assertEquals("1999", copiedMovie.getYear());
-	}
+//	@Test
+//	public void testCopy(){
+//		Movie movie = new Movie();
+//		movie.setYear("1999");
+//		movie.setTitle("Matrix");
+//
+//		Movie copiedMovie = movieUtil.copyMovie(movie);
+//		assertEquals("Matrix", copiedMovie.getTitle());
+//		assertEquals("1999", copiedMovie.getYear());
+//	}
 
 	@Test
 	public void testTopMovieCopy(){


### PR DESCRIPTION
-refactored the way users and movies are mapped together. Created a separate join entity to link the relationship between users and movies.
-Previously, movie entries had to be duplicated in the DB, now movies are checked for and saved if not in the DB, and queried from the table or the API.
-Added a new user_rating field for movies, to allow users to provide their own rating for each movie that has been watched on their list.
-Changes to the personal-list page had to be made.
-Removed redundant queries from the old movie dao / service classes and logic from the controller.